### PR TITLE
Ajouter un éditeur et une vue HTML des champs de textes "Description" et "Témoignages"

### DIFF
--- a/backend/static/css/comparator.css
+++ b/backend/static/css/comparator.css
@@ -126,3 +126,9 @@
     width: 100px;
     cursor: pointer;
 }
+
+.linebreak {
+    white-space: pre-line;
+    line-height: 1.2em;
+    margin-top: -1.2em;
+}

--- a/backend/tpl/comparator.html
+++ b/backend/tpl/comparator.html
@@ -112,8 +112,15 @@
         <div class="col-lg-7 pr-0">
           <h5 class="text-uppercase">{{ _('obs_point.description') }}</h5>
           <div class="text-collapse" ref="text_collapse_description" v-bind:class="textCollapseClsDescription">
+            {% if dbconf.enable_html_text == 'True' %}
             <div class="target font-italic">
-              {{ site.desc_site }}
+              {% autoescape false %}
+                {{ site.desc_site | replace("\n", "<br>") }}
+              {% endautoescape %}
+            {% else %}
+            <div class="target font-italic-linebreak">
+                {{ site.desc_site }}
+            {% endif %}
             </div>
             <div class="gradient text-right visible-text-collapsable pt-3">
               <button class="btn btn-sm btn-secondary font-weight-bold visible-text-collapsable" @click="toggleTextCollapse('description')">
@@ -125,8 +132,15 @@
           {% if site.testim_site %}
           <h5 class="text-uppercase mt-4">{{ _('obs_point.testimonials') }}</h5>
           <div class="text-collapse" ref="text_collapse_testimonial" v-bind:class="textCollapseClsTestimonial">
+            {% if dbconf.enable_html_text == 'True' %}
             <div class="target font-italic">
-              {{ site.testim_site }}
+              {% autoescape false %}
+                {{ site.testim_site | replace("\n", "<br>") }}
+              {% endautoescape %}
+            {% else %}
+            <div class="target font-italic-linebreak">
+                {{ site.testim_site }}
+            {% endif %}
             </div>
             <div class="gradient text-right visible-text-collapsable pt-3">
               <button class="btn btn-sm btn-secondary font-weight-bold visible-text-collapsable" @click="toggleTextCollapse('testimonial')">

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -131,7 +131,7 @@ Vous pouvez personnaliser l'application en modifiant et ajoutant des fichiers da
 
 Certains paramètres sont dans la table conf :
 
-- external_links, les liens en bas à droite dans le footer, est un tableu d'objets devant contenir un label et une url, ex.
+- ``external_links``, les liens en bas à droite dans le footer, est un tableu d'objets devant contenir un label et une url, ex.
 ::
 
         [{
@@ -142,10 +142,10 @@ Certains paramètres sont dans la table conf :
             "url": "http://rando.vanoise.com"
         }]
 
-- zoom_map_comparator, la valeur du zoom à l'initialisation de la carte de page comparateur de photos
-- zoom_max_fitbounds_map, la valeur du zoom max lorsqu'on filtre les points sur la carte interactive. Ce paramètre évite que le zoom soit trop important lorsque les points restant sont très rapprochés.
-- Si vous voyez un paramètre nommé zoom_map, sachez qu'il est déprécié, vous pouvez le supprimer de la table.
-- map_layers, les différentes couches disponibles sur la carte interactive, voir ce lien pour connaitre toutes les options de configuration https://leafletjs.com/reference-1.5.0.html#tilelayer, ex :
+- ``zoom_map_comparator``, la valeur du zoom à l'initialisation de la carte de page comparateur de photos
+- ``zoom_max_fitbounds_map``, la valeur du zoom max lorsqu'on filtre les points sur la carte interactive. Ce paramètre évite que le zoom soit trop important lorsque les points restant sont très rapprochés.
+- Si vous voyez un paramètre nommé ``zoom_map``, sachez qu'il est déprécié, vous pouvez le supprimer de la table.
+- ``map_layers``, les différentes couches disponibles sur la carte interactive, voir ce lien pour connaitre toutes les options de configuration https://leafletjs.com/reference-1.5.0.html#tilelayer, ex :
 ::
 
         [
@@ -166,6 +166,8 @@ Certains paramètres sont dans la table conf :
             }
           }
         ]
+
+- ``enable_html_text``, autorise l'interprétation du HTML contenu dans les champs de type texte "Description" et "Témoignage" (dans les fiches des points d'observation).
 
 Internationalisation de l'application
 ======================================   
@@ -201,6 +203,9 @@ Editer le fichier de configuration ``./front-backOffice/src/app/config.ts.tpl``.
     Pour utiliser l'utilisateur admin installé par defaut il faut Renseigner  id_application : 1
     
     Pour apiUrl et staticPicturesUrl, bien mettre http://xxx.xxx.xxx.xxx, si utilisation d'une adresse IP
+
+    Pour activer l'éditeur de texte HTML (WYSIWYG) RichTextEditor sur les champs "Description" et "Témoignage", renseigner enable_html_text_editor : 'True'. 
+    /!\ Cela permet aux utilisateurs ayant accès au back-office d'injecter du HTML dans le site --> A utiliser avec parcimonie en évaluant les incidences en matière de sécurité.
     
 
 **2. Lancer l'installation automatique de l'application :**

--- a/front-backOffice/angular.json
+++ b/front-backOffice/angular.json
@@ -31,7 +31,16 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "./node_modules/leaflet-draw/dist/leaflet.draw.css",
               "node_modules/ngx-toastr/toastr.css" ,
-              "./node_modules/leaflet/dist/leaflet.css"
+              "./node_modules/leaflet/dist/leaflet.css",
+              "node_modules/@syncfusion/ej2-base/styles/material.css",
+              "node_modules/@syncfusion/ej2-icons/styles/material.css",
+              "node_modules/@syncfusion/ej2-buttons/styles/material.css",
+              "node_modules/@syncfusion/ej2-splitbuttons/styles/material.css",
+              "node_modules/@syncfusion/ej2-inputs/styles/material.css",
+              "node_modules/@syncfusion/ej2-lists/styles/material.css",
+              "node_modules/@syncfusion/ej2-navigations/styles/material.css",
+              "node_modules/@syncfusion/ej2-popups/styles/material.css",
+              "node_modules/@syncfusion/ej2-richtexteditor/styles/material.css"
             ],
             "scripts": ["node_modules/leaflet/dist/leaflet.js"]
           },

--- a/front-backOffice/package.json
+++ b/front-backOffice/package.json
@@ -26,6 +26,7 @@
     "@ng-bootstrap/ng-bootstrap": "^4.0.0",
     "@ng-select/ng-select": "^2.12.1",
     "@swimlane/ngx-datatable": "^14.0.0",
+    "@syncfusion/ej2-angular-richtexteditor": "^18.1.54",
     "@types/lodash": "^4.14.118",
     "@types/moment": "^2.13.0",
     "bootstrap": "^4.1.3",

--- a/front-backOffice/src/app/add-site/add-site.component.html
+++ b/front-backOffice/src/app/add-site/add-site.component.html
@@ -81,14 +81,24 @@
           </div>
           <div class="form-group">
             <label class="label" for="desc">DESCRIPTION</label>
-            <textarea InputFeedBack class="form-control" formControlName="desc_site" placeholder="Ecrivez ici la description du site"
-              id="desc" rows="3"></textarea>
+            <div *ngIf="enableHtmlEdit == 'True'; then descRTE else descTXT"></div>
+              <ng-template #descRTE>
+                <ejs-richtexteditor #defaultRTE id='desc' [toolbarSettings]='tools' InputFeedBack formControlName="desc_site" placeholder="Ecrivez ici la description du site"></ejs-richtexteditor>
+              </ng-template>
+              <ng-template #descTXT>
+                <textarea InputFeedBack class="form-control" formControlName="desc_site" placeholder="Ecrivez ici la description du site" id="desc" rows="3"></textarea>
+              </ng-template>
             <app-form-error controlName="desc_site" errorKey="required"></app-form-error>
           </div>
           <div class="form-group">
             <label class="label" for="testim">TÉMOIGNAGE</label>
-            <textarea InputFeedBack class="form-control" formControlName="testim_site" placeholder="Ecrivez ici les témoignages"
-              id="testim" rows="3"></textarea>
+            <div *ngIf="enableHtmlEdit == 'True'; then testimRTE else testimTXT"></div>
+              <ng-template #testimRTE>
+                <ejs-richtexteditor #defaultRTE id='testim' [toolbarSettings]='tools' InputFeedBack formControlName="testim_site" placeholder="Ecrivez ici les témoignages"></ejs-richtexteditor>
+              </ng-template>
+              <ng-template #testimTXT>
+                <textarea InputFeedBack class="form-control" formControlName="testim_site" placeholder="Ecrivez ici les témoignages" id="testim" rows="3"></textarea>
+              </ng-template>
             <app-form-error controlName="testim_site" errorKey="required"></app-form-error>
           </div>
           <div class="form-group">

--- a/front-backOffice/src/app/add-site/add-site.component.ts
+++ b/front-backOffice/src/app/add-site/add-site.component.ts
@@ -13,14 +13,31 @@ import { ToastrService } from 'ngx-toastr';
 import { forkJoin } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { NgxSpinnerService } from 'ngx-spinner';
+import { ToolbarService, LinkService, ImageService, HtmlEditorService } from '@syncfusion/ej2-angular-richtexteditor';
 
 @Component({
   selector: 'app-add-site',
   templateUrl: './add-site.component.html',
   styleUrls: ['./add-site.component.scss'],
-
+  providers: [ToolbarService, LinkService, ImageService, HtmlEditorService],
 })
+
 export class AddSiteComponent implements OnInit, OnDestroy {
+  /* RichTextEditor toolbar configuration --> Hide image upload tool */
+  public tools: object = {
+    type: 'Expand',
+    items: ['Bold', 'Italic', 'Underline', 'StrikeThrough',
+      'FontName', 'FontSize', 'FontColor', 'BackgroundColor',
+      'LowerCase', 'UpperCase', '|',
+      'Formats', 'Alignments', 'OrderedList', 'UnorderedList',
+      'Outdent', 'Indent', '|',
+      'CreateLink',
+      /*'Image', */
+      '|', 'ClearFormat', 'Print',
+      'SourceCode', 'FullScreen', '|', 'Undo', 'Redo']
+  };
+  /* Set config.ts parameter to enable RTE display */
+  enableHtmlEdit = Conf.enable_html_text_editor;
   selectedFile: File[];
   modalRef: NgbModalRef;
   selectedSubthemes = [];

--- a/front-backOffice/src/app/app.module.ts
+++ b/front-backOffice/src/app/app.module.ts
@@ -53,7 +53,8 @@ import { NgxSpinnerModule } from 'ngx-spinner';
     NgSelectModule,
     BrowserAnimationsModule,
     ToastrModule.forRoot(),
-    NgxSpinnerModule
+    NgxSpinnerModule,
+    RichTextEditorAllModule
   ],
   providers: [
     LoginService,

--- a/front-backOffice/src/app/config.ts.tpl
+++ b/front-backOffice/src/app/config.ts.tpl
@@ -4,5 +4,6 @@ export const Conf = {
     id_application: id_app,
     ign_Key : 'ign key',
     map_lat_center: 45.372167,
-    map_lan_center: 6.819077
+    map_lan_center: 6.819077,
+    enable_html_text_editor : 'False' /* Enable HTML editor on description and testimonial fields --> 'True' OR 'False' */
  };

--- a/install_configuration/oppvdb.sql
+++ b/install_configuration/oppvdb.sql
@@ -148,6 +148,7 @@ INSERT INTO geopaysages.conf (key, value) VALUES ('external_links', '[{
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map', '18');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_max_fitbounds_map', '13');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map_comparator', '13');
+INSERT INTO geopaysages.conf (key, value) VALUES ('enable_html_text', 'True');
 
 --
 -- TOC entry 3814 (class 0 OID 21076)


### PR DESCRIPTION
Propositions en lien avec #82 :

- Interprétation des sauts de lignes dans les champs de textes en en utilisant le paramètre CSS ``white-space: pre-line;``
- Interprétation du HTML contenu dans les champs de textes "Description" et "Témoignage" sur la page ``/comparator`` (fiche point d'observation) --> Défini par le paramètre de configuration ``enable_html_text`` ('True' ou 'False') dans la table ``geopaysages.conf``de la BD.
- Ajout d'un éditeur de texte HTML WYSIWYG (module Angular Rich Text Editor) sur le formulaire d'édition des points d'observation du back-office --> Défini par le paramètre de configuration ``enable_html_text_editor`` ('True' ou 'False') dans le fichier ``./front-backOffice/src/app/config.ts.tpl``
- Mise à jour de la documentation

 **_NB :_** Je ne suis pas développeur. Merci de votre indulgence et de vos retours, commentaires, corrections...
