### PR TITLE
Ajustements mineurs : CSS, Doc et DEFAULT_SORT_SITE

### DIFF
--- a/backend/i18n/fr/LC_MESSAGES/messages.po
+++ b/backend/i18n/fr/LC_MESSAGES/messages.po
@@ -154,6 +154,27 @@ msgstr "filtres : %(nb)s résultat(s)"
 msgid "sites.observation_points.title"
 msgstr "Sites d'observation"
 
+#: backend/tpl/comparator-v2.html:6
+msgid "comparatorv2.mode.title"
+msgstr "Disposition des photos"
+
+#: backend/tpl/comparator-v2.html:33
+msgid "comparatorv2.loading"
+msgstr "Chargement"
+
+#: backend/tpl/comparator-v2.html:43
+msgid "comparatorv2.date.filter.title"
+msgstr "Filtrer par date"
+
+#: backend/tpl/comparator-v2.html:45
+msgid "comparatorv2.date.filter.start"
+msgstr "Début"
+
+#: backend/tpl/comparator-v2.html:54
+msgid "comparatorv2.date.filter.end"
+msgstr "Fin"
+
+
 #~ msgid "map.filter.themes"
 #~ msgstr "Thème"
 

--- a/backend/i18n/messages.pot
+++ b/backend/i18n/messages.pot
@@ -153,3 +153,22 @@ msgstr ""
 msgid "sites.observation_points.title"
 msgstr ""
 
+#: backend/tpl/comparatorv2.html:6
+msgid "comparatorv2.mode.title"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:33
+msgid "comparatorv2.loading"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:43
+msgid "comparatorv2.date.filter.title"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:45
+msgid "comparatorv2.date.filter.start"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:54
+msgid "comparatorv2.date.filter.end"
+msgstr ""

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -107,7 +107,7 @@ def home():
 
 @main.route('/gallery')
 def gallery():
-    get_sites = models.TSite.query.filter_by(publish_site = True).order_by('name_site')
+    get_sites = models.TSite.query.filter_by(publish_site = True).order_by(DEFAULT_SORT_SITES)
     dump_sites = site_schema.dump(get_sites).data
     
     #TODO get photos and cities by join on sites query

--- a/backend/static/css/comparator-v2.css
+++ b/backend/static/css/comparator-v2.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   --tools-top: 50px;
+  font-family: 'Hind', sans-serif;
 }
 @media (min-width: 576px) {
   .page-site .app-comparator {
@@ -66,4 +67,8 @@
 }
 .page-site .app-comparator .photo-caption.right {
   right: 0;
+}
+
+.page-site .app-comparator .date_filter_title {
+  font-weight: bold;
 }

--- a/backend/static/css/sites.css
+++ b/backend/static/css/sites.css
@@ -59,6 +59,14 @@
   width: 100%;
 }
 
+.app-sites .sidebar .text-right .align-text-top {
+    font-family: 'Hind', sans-serif;
+}
+
+.app-sites .sidebar .text-right .mr-1 {
+    margin-right: 0 !important;
+}
+
 .app-sites .sidebar .filters .card-header .btn .icon {
     right: auto;
     left: -10px;

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -3,7 +3,7 @@
     <div class="mode-selector d-flex mb-1 mb-sm-0">
       <div class="col-6 p-0 justify-content-end d-flex">
         <span class="mode-selector-label">
-          <span class="pr-2">Disposition des photos</span>
+          <span class="pr-2">{{ _('comparatorv2.mode.title') }}</span>
         </span>
       </div>
       <b-dropdown :text="curMode.label">
@@ -30,7 +30,7 @@
     </div>
     <b-modal id="comparatorLoading" class="modal-contained" size="sm" static lazy centered no-fade no-close-on-backdrop
       no-close-on-esc hide-header hide-footer>
-      <p class="mb-0">Chargement</p>
+      <p class="mb-0">{{ _('comparatorv2.loading') }}</p>
       <b-progress :value="100" variant="info" animated class="mt-1"></b-progress>
     </b-modal>
   </div>
@@ -40,9 +40,9 @@
   <div class="photo-selector">
     <b-dropdown :text="selectedItem?.shot_on | dateFormat" lazy no-flip :right="right" class="date-selector">
       <div class="mx-2">
-        <span class="date_filter_title">Filtrer par date</span>
+        <span class="date_filter_title">{{ _('comparatorv2.date.filter.title') }}</span>
         <div class="d-flex justify-content-between align-items-center">
-          <span>Début</span>
+          <span>{{ _('comparatorv2.date.filter.start') }}</span>
           <div>
             <input type="date" v-model="dateFrom" />
             <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateFrom = null">
@@ -51,7 +51,7 @@
           </div>
         </div>
         <div class="d-flex justify-content-between align-items-center mt-1">
-          <span>Fin</span>
+          <span>{{ _('comparatorv2.date.filter.end') }}</span>
           <div>
             <input type="date" v-model="dateTo" />
             <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateTo = null">

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -40,7 +40,7 @@
   <div class="photo-selector">
     <b-dropdown :text="selectedItem?.shot_on | dateFormat" lazy no-flip :right="right" class="date-selector">
       <div class="mx-2">
-        Filtrer par date
+        <span class="date_filter_title">Filtrer par date</span>
         <div class="d-flex justify-content-between align-items-center">
           <span>Début</span>
           <div>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -181,7 +181,7 @@ Vous pouvez personnaliser l'application en modifiant et ajoutant des fichiers da
 
 L'éventuelle surcouche CSS est à réaliser dans le fichier ``custom/css/custom-style.css``.
 
-Certains paramètres sont dans la table ``conf`` :
+Certains paramètres sont gérés depuis la table ``geopaysages.conf`` de la base de données :
 
 - ``external_links``, les liens en bas à droite dans le footer, est un tableau d'objets devant contenir un label et une URL, ex.
 ::
@@ -195,8 +195,9 @@ Certains paramètres sont dans la table ``conf`` :
         }]
 
 - ``zoom_map_comparator``, la valeur du zoom à l'initialisation de la carte de page comparateur de photos
+
 - ``zoom_max_fitbounds_map``, la valeur du zoom max lorsqu'on filtre les points sur la carte des sites d'observations. Ce paramètre évite que le zoom soit trop important lorsque les points restant sont très rapprochés.
-- Si vous voyez un paramètre nommé ``zoom_map``, sachez qu'il est déprécié, vous pouvez le supprimer de la table.
+
 - ``map_layers``, les différentes couches disponibles sur les cartes, voir ce lien pour connaitre toutes les options de configuration https://leafletjs.com/reference-1.5.0.html#tilelayer, ex :
 ::
 
@@ -218,6 +219,7 @@ Certains paramètres sont dans la table ``conf`` :
             }
           }
         ]
+
 
 Activation du bloc d'intro en page d'accueil
 ============================================

--- a/install_configuration/oppdb.sql
+++ b/install_configuration/oppdb.sql
@@ -145,7 +145,6 @@ INSERT INTO geopaysages.conf (key, value) VALUES ('external_links', '[{
     "url": "https://phototheque.vanoise-parcnational.fr"
 }]
 ');
-INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map', '18');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_max_fitbounds_map', '13');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map_comparator', '13');
 


### PR DESCRIPTION
- Ajustements CSS sur les textes du comparateur v2 (page `site`) + celui des filtres actifs (page `sites`)
- Ajout de variables d'internationalisation dans le template `comparator-v2.html` 
- Utilisation du paramètre `DEFAULT_SORT_SITES` pour l'ordre des sites dans la page `gallery`
- Suppression d'un paramètre de configuration déprécié dans la DOC et dans le SQL d'install