### PR TITLE
Comparateur v2 - Ajout de paramètres de personnalisation

### DIFF
--- a/backend/i18n/fr/LC_MESSAGES/messages.po
+++ b/backend/i18n/fr/LC_MESSAGES/messages.po
@@ -154,6 +154,27 @@ msgstr "filtres : %(nb)s résultat(s)"
 msgid "sites.observation_points.title"
 msgstr "Sites d'observation"
 
+#: backend/tpl/comparator-v2.html:6
+msgid "comparatorv2.mode.title"
+msgstr "Disposition des photos"
+
+#: backend/tpl/comparator-v2.html:33
+msgid "comparatorv2.loading"
+msgstr "Chargement"
+
+#: backend/tpl/comparator-v2.html:43
+msgid "comparatorv2.date.filter.title"
+msgstr "Filtrer par date"
+
+#: backend/tpl/comparator-v2.html:45
+msgid "comparatorv2.date.filter.start"
+msgstr "Début"
+
+#: backend/tpl/comparator-v2.html:54
+msgid "comparatorv2.date.filter.end"
+msgstr "Fin"
+
+
 #~ msgid "map.filter.themes"
 #~ msgstr "Thème"
 

--- a/backend/i18n/messages.pot
+++ b/backend/i18n/messages.pot
@@ -153,3 +153,22 @@ msgstr ""
 msgid "sites.observation_points.title"
 msgstr ""
 
+#: backend/tpl/comparatorv2.html:6
+msgid "comparatorv2.mode.title"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:33
+msgid "comparatorv2.loading"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:43
+msgid "comparatorv2.date.filter.title"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:45
+msgid "comparatorv2.date.filter.start"
+msgstr ""
+
+#: backend/tpl/comparator-v2.html:54
+msgid "comparatorv2.date.filter.end"
+msgstr ""

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -107,7 +107,7 @@ def home():
 
 @main.route('/gallery')
 def gallery():
-    get_sites = models.TSite.query.filter_by(publish_site = True).order_by('name_site')
+    get_sites = models.TSite.query.filter_by(publish_site = True).order_by(DEFAULT_SORT_SITES)
     dump_sites = site_schema.dump(get_sites).data
     
     #TODO get photos and cities by join on sites query

--- a/backend/static/css/comparator-v2.css
+++ b/backend/static/css/comparator-v2.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   --tools-top: 50px;
+  font-family: 'Hind', sans-serif;
 }
 @media (min-width: 576px) {
   .page-site .app-comparator {
@@ -66,4 +67,8 @@
 }
 .page-site .app-comparator .photo-caption.right {
   right: 0;
+}
+
+.page-site .app-comparator .date_filter_title {
+  font-weight: bold;
 }

--- a/backend/static/css/sites.css
+++ b/backend/static/css/sites.css
@@ -59,6 +59,14 @@
   width: 100%;
 }
 
+.app-sites .sidebar .text-right .align-text-top {
+    font-family: 'Hind', sans-serif;
+}
+
+.app-sites .sidebar .text-right .mr-1 {
+    margin-right: 0 !important;
+}
+
 .app-sites .sidebar .filters .card-header .btn .icon {
     right: auto;
     left: -10px;

--- a/backend/static/js/comparator-v2.js
+++ b/backend/static/js/comparator-v2.js
@@ -31,11 +31,24 @@ geopsg.comparator = (options) => {
 
   //TODO use format as an argument
   Vue.filter('dateFormat', (value) => {
+    if (options.dbconf.comparator_date_format == 'year') {
+    return value.toLocaleString('fr-FR', {
+      year: 'numeric'
+    });
+    }
+    if (options.dbconf.comparator_date_format == 'month') {
+    return value.toLocaleString('fr-FR', {
+      month: '2-digit',
+      year: 'numeric'
+    });
+    }
+    else {
     return value.toLocaleString('fr-FR', {
       month: '2-digit',
       day: '2-digit',
       year: 'numeric'
     });
+  }
   });
 
   Vue.component('app-comparator-v2', {
@@ -164,30 +177,65 @@ geopsg.comparator = (options) => {
     template: '#tpl-app-comparator-v2-selector',
     props: ['items', 'selectedItem', 'right'],
     data: () => {
-      return {
-        dateFrom: null,
-        dateTo: null,
-        currentPage: 1,
-        perPage: 10,
-        pageItems: [],
-        nbFilteredItems: 0,
-        steps: [{
-          label: "0",
-          value: 0
-        }, {
-          label: "1 jour",
-          value: 3600 * 24
-        }, {
-          label: "1 semaine",
-          value: 3600 * 24 * 7
-        }, {
-          label: "1 mois",
-          value: 3600 * 24 * 30
-        }, {
-          label: "1 an",
-          value: 3600 * 24 * 365
-        }],
-        selectedStep: null
+      if (options.dbconf.comparator_date_format == 'year') {
+        return {
+          dateFrom: null,
+          dateTo: null,
+          currentPage: 1,
+          perPage: 10,
+          pageItems: [],
+          nbFilteredItems: 0,
+          steps: [{
+            label: "1 an",
+            value: 3600 * 24 * 365
+          }],
+          selectedStep: null
+        }
+      }
+      if (options.dbconf.comparator_date_format == 'month') {
+        return {
+          dateFrom: null,
+          dateTo: null,
+          currentPage: 1,
+          perPage: 10,
+          pageItems: [],
+          nbFilteredItems: 0,
+          steps: [{
+            label: "1 mois",
+            value: 3600 * 24 * 30
+          }, {
+            label: "1 an",
+            value: 3600 * 24 * 365
+          }],
+          selectedStep: null
+        }
+      }
+      else {
+        return {
+          dateFrom: null,
+          dateTo: null,
+          currentPage: 1,
+          perPage: 10,
+          pageItems: [],
+          nbFilteredItems: 0,
+          steps: [{
+            label: "0",
+            value: 0
+          }, {
+            label: "1 jour",
+            value: 3600 * 24
+          }, {
+            label: "1 semaine",
+            value: 3600 * 24 * 7
+          }, {
+            label: "1 mois",
+            value: 3600 * 24 * 30
+          }, {
+            label: "1 an",
+            value: 3600 * 24 * 365
+          }],
+          selectedStep: null
+        }
       }
     },
     beforeMount() {

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -75,9 +75,9 @@
     <div class="d-block d-lg-inline-block mt-1 mt-lg-0">
       <b-button v-on:click="onPrevBtnClick()">&lt;</b-button>
       <b-button v-on:click="onNextBtnClick()">&gt;</b-button>
-      <b-dropdown :text="'Pas : ' + selectedStep?.label" toggle-class="btn-no-uppercase" class="d-block d-md-inline-block mt-1 mt-md-0" no-flip :right="right">
       {% if dbconf.comparator_date_step_button == 'False': %}
       {% else %}
+      <b-dropdown :text="'Pas : ' + selectedStep?.label" toggle-class="btn-no-uppercase" class="d-block d-md-inline-block mt-1 mt-md-0" no-flip :right="right">
         <b-dropdown-item-button v-for="step in steps" v-bind:key="step.value" v-on:click="onStepClick(step)">
           <span :inner-html.prop="step.label"></span>
         </b-dropdown-item-button>

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -3,7 +3,7 @@
     <div class="mode-selector d-flex mb-1 mb-sm-0">
       <div class="col-6 p-0 justify-content-end d-flex">
         <span class="mode-selector-label">
-          <span class="pr-2">Disposition des photos</span>
+          <span class="pr-2">{{ _('comparatorv2.mode.title') }}</span>
         </span>
       </div>
       <b-dropdown :text="curMode.label">
@@ -30,7 +30,7 @@
     </div>
     <b-modal id="comparatorLoading" class="modal-contained" size="sm" static lazy centered no-fade no-close-on-backdrop
       no-close-on-esc hide-header hide-footer>
-      <p class="mb-0">Chargement</p>
+      <p class="mb-0">{{ _('comparatorv2.loading') }}</p>
       <b-progress :value="100" variant="info" animated class="mt-1"></b-progress>
     </b-modal>
   </div>
@@ -40,9 +40,9 @@
   <div class="photo-selector">
     <b-dropdown :text="selectedItem?.shot_on | dateFormat" lazy no-flip :right="right" class="date-selector">
       <div class="mx-2">
-        <span class="date_filter_title">Filtrer par date</span>
+        <span class="date_filter_title">{{ _('comparatorv2.date.filter.title') }}</span>
         <div class="d-flex justify-content-between align-items-center">
-          <span>Début</span>
+          <span>{{ _('comparatorv2.date.filter.start') }}</span>
           <div>
             <input type="date" v-model="dateFrom" />
             <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateFrom = null">
@@ -51,7 +51,7 @@
           </div>
         </div>
         <div class="d-flex justify-content-between align-items-center mt-1">
-          <span>Fin</span>
+          <span>{{ _('comparatorv2.date.filter.end') }}</span>
           <div>
             <input type="date" v-model="dateTo" />
             <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateTo = null">

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -40,7 +40,7 @@
   <div class="photo-selector">
     <b-dropdown :text="selectedItem?.shot_on | dateFormat" lazy no-flip :right="right" class="date-selector">
       <div class="mx-2">
-        Filtrer par date
+        <span class="date_filter_title">Filtrer par date</span>
         <div class="d-flex justify-content-between align-items-center">
           <span>Début</span>
           <div>

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -39,28 +39,31 @@
 <template id="tpl-app-comparator-v2-selector">
   <div class="photo-selector">
     <b-dropdown :text="selectedItem?.shot_on | dateFormat" lazy no-flip :right="right" class="date-selector">
-      <div class="mx-2">
-        <span class="date_filter_title">{{ _('comparatorv2.date.filter.title') }}</span>
-        <div class="d-flex justify-content-between align-items-center">
-          <span>{{ _('comparatorv2.date.filter.start') }}</span>
-          <div>
-            <input type="date" v-model="dateFrom" />
-            <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateFrom = null">
-              <span class="material-icons">clear</span>
-            </button>
+      {% if dbconf.comparator_date_filter == 'False': %}
+      {% else %}
+        <div class="mx-2">
+          <span class="date_filter_title">{{ _('comparatorv2.date.filter.title') }}</span>
+          <div class="d-flex justify-content-between align-items-center">
+            <span>{{ _('comparatorv2.date.filter.start') }}</span>
+            <div>
+              <input type="date" v-model="dateFrom" />
+              <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateFrom = null">
+                <span class="material-icons">clear</span>
+              </button>
+            </div>
+          </div>
+          <div class="d-flex justify-content-between align-items-center mt-1">
+            <span>{{ _('comparatorv2.date.filter.end') }}</span>
+            <div>
+              <input type="date" v-model="dateTo" />
+              <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateTo = null">
+                <span class="material-icons">clear</span>
+              </button>
+            </div>
           </div>
         </div>
-        <div class="d-flex justify-content-between align-items-center mt-1">
-          <span>{{ _('comparatorv2.date.filter.end') }}</span>
-          <div>
-            <input type="date" v-model="dateTo" />
-            <button class="btn btn-link px-1 py-0" type="button" v-on:click="dateTo = null">
-              <span class="material-icons">clear</span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <b-dropdown-divider></b-dropdown-divider>
+        <b-dropdown-divider></b-dropdown-divider>
+      {% endif %}
       <b-dropdown-item-button v-for="item in pageItems" v-bind:key="item.id" v-on:click="onItemClick(item)">
         <span :inner-html.prop="item.shot_on | dateFormat"></span>
       </b-dropdown-item-button>

--- a/backend/tpl/comparator-v2.html
+++ b/backend/tpl/comparator-v2.html
@@ -76,10 +76,13 @@
       <b-button v-on:click="onPrevBtnClick()">&lt;</b-button>
       <b-button v-on:click="onNextBtnClick()">&gt;</b-button>
       <b-dropdown :text="'Pas : ' + selectedStep?.label" toggle-class="btn-no-uppercase" class="d-block d-md-inline-block mt-1 mt-md-0" no-flip :right="right">
+      {% if dbconf.comparator_date_step_button == 'False': %}
+      {% else %}
         <b-dropdown-item-button v-for="step in steps" v-bind:key="step.value" v-on:click="onStepClick(step)">
           <span :inner-html.prop="step.label"></span>
         </b-dropdown-item-button>
       </b-dropdown>
+    {% endif %}
     </div>
   </div>
 </template>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -181,7 +181,7 @@ Vous pouvez personnaliser l'application en modifiant et ajoutant des fichiers da
 
 L'éventuelle surcouche CSS est à réaliser dans le fichier ``custom/css/custom-style.css``.
 
-Certains paramètres sont dans la table ``conf`` :
+Certains paramètres sont gérés depuis la table ``geopaysages.conf`` de la base de données :
 
 - ``external_links``, les liens en bas à droite dans le footer, est un tableau d'objets devant contenir un label et une URL, ex.
 ::
@@ -195,8 +195,9 @@ Certains paramètres sont dans la table ``conf`` :
         }]
 
 - ``zoom_map_comparator``, la valeur du zoom à l'initialisation de la carte de page comparateur de photos
+
 - ``zoom_max_fitbounds_map``, la valeur du zoom max lorsqu'on filtre les points sur la carte des sites d'observations. Ce paramètre évite que le zoom soit trop important lorsque les points restant sont très rapprochés.
-- Si vous voyez un paramètre nommé ``zoom_map``, sachez qu'il est déprécié, vous pouvez le supprimer de la table.
+
 - ``map_layers``, les différentes couches disponibles sur les cartes, voir ce lien pour connaitre toutes les options de configuration https://leafletjs.com/reference-1.5.0.html#tilelayer, ex :
 ::
 
@@ -218,6 +219,7 @@ Certains paramètres sont dans la table ``conf`` :
             }
           }
         ]
+
 
 Activation du bloc d'intro en page d'accueil
 ============================================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -220,6 +220,10 @@ Certains paramètres sont gérés depuis la table ``geopaysages.conf`` de la bas
           }
         ]
 
+Si vous utiliser la version 2 du comparateur photos (paramètre ``COMPARATOR_VERSION = 2`` dans ``config.py.tpl``), vous pouvez personnaliser celui-ci selon votre contexte. Notamment le simplifier dans le cas de série de photos sur des pas temps plutôt espacés (reconductions pluri-annuelles, annuelles voire mensuelles) :
+
+- ``comparator_date_filter``, permet d'activer ``True`` ou de désactiver ``False`` l'outil de filtrage par plage de dates (actif par défaut si le paramètre n'est pas renseigné). Celui-ci étant peu utile dans le cas de petites séries de photos ou de reconductions annuelles par exemple.
+
 
 Activation du bloc d'intro en page d'accueil
 ============================================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -226,6 +226,10 @@ Si vous utiliser la version 2 du comparateur photos (paramètre ``COMPARATOR_VER
 
 - ``comparator_date_step_button``, permet de masquer le bouton sélecteur de pas de temps. Si il est renseigné à ``False`` le bouton ne sera pas affiché et les boutons précédent/suivant fonctionneront sans distinction de pas de temps. Utile dans le cas de petite séries de photos.
 
+- ``comparator_date_format``, permet de personnaliser le format d'affichage des dates des photos dans le bouton sélecteur. Avec la valeur ``year`` on affiche la date au format ``YYYY``. Avec ``month`` --> ``MM/YYYY``.
+Le comportement par défaut reste l'affichage de la date complète au format ``day`` --> ``DD/MM/YYYY`` (si non-renseigné).
+Ce paramètre permet aussi de filtrer en conséquence les pas de temps disponibles dans le bouton ad-hoc (exemple : si ``month`` est défini, les pas de temps disponibles seront ``1 mois`` et ``1 an``). Utile dans le cas où les dates de photos sont parfois imprécises (photos ancienns, cartes postales...).
+
 
 Activation du bloc d'intro en page d'accueil
 ============================================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -224,6 +224,8 @@ Si vous utiliser la version 2 du comparateur photos (paramètre ``COMPARATOR_VER
 
 - ``comparator_date_filter``, permet d'activer ``True`` ou de désactiver ``False`` l'outil de filtrage par plage de dates (actif par défaut si le paramètre n'est pas renseigné). Celui-ci étant peu utile dans le cas de petites séries de photos ou de reconductions annuelles par exemple.
 
+- ``comparator_date_step_button``, permet de masquer le bouton sélecteur de pas de temps. Si il est renseigné à ``False`` le bouton ne sera pas affiché et les boutons précédent/suivant fonctionneront sans distinction de pas de temps. Utile dans le cas de petite séries de photos.
+
 
 Activation du bloc d'intro en page d'accueil
 ============================================

--- a/install_configuration/oppdb.sql
+++ b/install_configuration/oppdb.sql
@@ -145,7 +145,6 @@ INSERT INTO geopaysages.conf (key, value) VALUES ('external_links', '[{
     "url": "https://phototheque.vanoise-parcnational.fr"
 }]
 ');
-INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map', '18');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_max_fitbounds_map', '13');
 INSERT INTO geopaysages.conf (key, value) VALUES ('zoom_map_comparator', '13');
 


### PR DESCRIPTION
En référence à #102 : 
/!\ Cette PR intègre les modifications proposées dans la PR #101 

Proposition d'ajout de paramètres pour simplifier / personnaliser le comparateur de photos v2 + MàJ de la doc :

- ``comparator_date_filter``, permet d'activer ``True`` ou de désactiver ``False`` l'outil de filtrage par plage de dates (actif par défaut si le paramètre n'est pas renseigné). Celui-ci étant peu utile dans le cas de petites séries de photos ou de reconductions annuelles par exemple.

- ``comparator_date_format``, permet de personnaliser le format d'affichage des dates des photos dans le bouton sélecteur. Avec la valeur ``year`` on affiche la date au format ``YYYY``. Avec ``month`` --> ``MM/YYYY``.
Le comportement par défaut reste l'affichage de la date complète au format ``day`` --> ``DD/MM/YYYY`` (si non-renseigné).
Ce paramètre permet aussi de filtrer en conséquence les pas de temps disponibles dans le bouton ad-hoc (exemple : si ``month`` est défini, les pas de temps disponibles seront ``1 mois`` et ``1 an``). Utile dans le cas où les dates de photos sont parfois imprécises (photos ancienns, cartes postales...).

- ``comparator_date_step_button``, permet de masquer le bouton sélecteur de pas de temps. Si il est renseigné à ``False`` le bouton ne sera pas affiché et les boutons précédent/suivant fonctionneront sans distinction de pas de temps. Utile dans le cas de petite séries de photos.