### PR TITLE
install_app.sh : corrections mineures

### DIFF
--- a/install_app.sh
+++ b/install_app.sh
@@ -22,17 +22,20 @@ pip install -r ./backend/requirements.txt
 
 
 cp backend/static/custom/images/sample.png.sample backend/static/custom/images/sample.png
-cp backend/static/custom/css/page-style.css.sample backend/static/custom/css/page-style.css
+cp backend/static/custom/css/custom-style.css.sample backend/static/custom/css/custom-style.css
 cp backend/static/custom/css/page-sample.css.sample backend/static/custom/css/page-sample.css
 cp backend/static/custom/logo/logo_txt_blanc.png.sample backend/static/custom/logo/logo_txt_blanc.png
 cp backend/static/custom/logo/logo_txt_color.png.sample backend/static/custom/logo/logo_txt_color.png
-cp backend/static/custom/logo/favicon.icon.sample backend/static/custom/logo/favicon.icon
-cp i18n/messages.pot.sample i18n/messages.pot 
-cp i18n/fr/LC_MESSAGES/messages.mo.sample i18n/fr/LC_MESSAGES/messages.mo
-cp i18n/fr/LC_MESSAGES/messages.po.sample i18n/fr/LC_MESSAGES/messages.po
+cp backend/static/custom/logo/favicon.ico.sample backend/static/custom/logo/favicon.ico
+cp backend/i18n/messages.pot.sample backend/i18n/messages.pot 
+cp backend/i18n/fr/LC_MESSAGES/messages.mo.sample backend/i18n/fr/LC_MESSAGES/messages.mo
+cp backend/i18n/fr/LC_MESSAGES/messages.po.sample backend/i18n/fr/LC_MESSAGES/messages.po
 
 
 cp ./backend/static/assets/images/oppv-005-03-2014.jpg ../data/images/
 cp ./backend/static/assets/images/oppv-005-00-2006.jpg ../data/images/
+
+pybabel compile -d backend/i18n
+sudo supervisorctl reload
 
 deactivate


### PR DESCRIPTION
Suite à des tests en fresh install de la future v1.2.0 : 

- corrections de certains chemins incorrects dans les commandes `cp`
- ajout de la commande de compilation des fichiers de langues durant l'install (celui par défaut) + reload supervisor